### PR TITLE
Initialize pnpm workspace with CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "followup",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 
 # Others
 .DS_Store
+.venv

--- a/backend/.devcontainer/devcontainer.json
+++ b/backend/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "followup-backend",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@followup/backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "echo 'no lint'",
+    "test": "echo 'no tests'"
+  }
+}

--- a/frontend/.devcontainer/devcontainer.json
+++ b/frontend/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "followup-frontend",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@followup/frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "echo 'no lint'",
+    "test": "echo 'no tests'"
+  }
+}

--- a/infra/.devcontainer/devcontainer.json
+++ b/infra/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "followup-infra",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@followup/infra",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "echo 'no lint'",
+    "test": "echo 'no tests'"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "followup",
+  "version": "0.1.0",
+  "private": true,
+  "workspaces": [
+    "backend",
+    "frontend",
+    "shared",
+    "infra",
+    "scripts"
+  ],
+  "scripts": {
+    "lint": "pnpm -r lint",
+    "test": "pnpm -r test"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,19 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  backend: {}
+
+  frontend: {}
+
+  infra: {}
+
+  scripts: {}
+
+  shared: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - 'backend'
+  - 'frontend'
+  - 'shared'
+  - 'infra'
+  - 'scripts'

--- a/scripts/.devcontainer/devcontainer.json
+++ b/scripts/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "followup-scripts",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install system packages
+sudo apt-get update
+sudo apt-get install -y curl git python3 python3-pip python3-venv
+
+# Install Node and pnpm
+curl -fsSL https://get.pnpm.io/install.sh | sh -
+
+# Install python tooling
+python3 -m pip install --upgrade pip
+pip install flake8 black mypy
+
+# Install JS tooling globally
+pnpm add -g eslint prettier flow-bin stylelint

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@followup/scripts",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "echo 'no lint'",
+    "test": "echo 'no tests'"
+  }
+}

--- a/shared/.devcontainer/devcontainer.json
+++ b/shared/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "followup-shared",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@followup/shared",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "echo 'no lint'",
+    "test": "echo 'no tests'"
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap pnpm workspace with backend/frontend/shared/infra/scripts packages
- add minimal devcontainer placeholders
- configure GitHub Actions workflow to run lint and test
- provide `scripts/codex_setup.sh` for environment setup

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687d69946ff083299af874bed927a795