### PR TITLE
Add Docker setup for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This repository hosts the source code and documentation for FollowUp.ai, a WhatsApp CRM.
 
 To understand the system architecture and guidelines, read the [development blueprint](./blueprint.md).
+
+## Development with Docker
+
+To run the backend and frontend services locally, ensure Docker is installed and execute:
+
+```sh
+docker compose up --build
+```
+
+The frontend will be available at http://localhost:3000 and the backend at http://localhost:3001.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-slim
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+COPY backend ./backend
+RUN corepack enable && pnpm install --frozen-lockfile --filter @followup/backend...
+WORKDIR /app/backend
+EXPOSE 3000
+CMD ["pnpm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "3001:3000"
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-slim
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+COPY frontend ./frontend
+RUN corepack enable && pnpm install --frozen-lockfile --filter @followup/frontend...
+WORKDIR /app/frontend
+EXPOSE 3000
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## Summary
- create Dockerfiles for backend and frontend services
- define docker-compose.yml to run both services
- document docker usage in README

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_687d72637a348329a907a52325fdd038