### PR TITLE
Add Sphinx docs and build workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          npm install -g pnpm
+          pnpm install
+          python -m pip install --upgrade pip
+          pip install sphinx
+      - name: Run tests
+        run: pnpm test
+      - name: Build docs
+        run: sphinx-build -b html -n -W docs/source docs/build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/configure-pages@v5
+      - uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ __pycache__/
 # Others
 .DS_Store
 .venv
+docs/build/
+docs/source/_build/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ pnpm test
 
 These commands delegate to each package's `lint` and `test` scripts.
 
+## Building Documentation
+
+Build the HTML documentation locally with Sphinx:
+
+```bash
+cd docs
+make -C source html
+```
+
+The generated site can be found in `docs/source/_build/html`.
+
 ## Contributing
 
 Refer to [`docs/backlog.md`](./docs/backlog.md) for planned work. Please mention the backlog item you are addressing when opening a pull request.

--- a/backend/messaging_core/__init__.py
+++ b/backend/messaging_core/__init__.py
@@ -1,0 +1,1 @@
+"""Messaging core package."""

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "scripts": {
     "lint": "eslint .",
-    "test": "pytest ../tests"
+    "test": "pytest -W error ../tests"
   }
 }

--- a/docs/source/Makefile
+++ b/docs/source/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,32 @@
+"""Sphinx configuration for project documentation."""
+
+#
+# For the full list of built-in configuration values, see
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "FollowUp.ai"
+copyright = "2025, FollowUp.ai Contributors"
+author = "FollowUp.ai Contributors"
+
+version = "0.1"
+release = "0.1"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,17 @@
+.. FollowUp.ai documentation master file, created by
+   sphinx-quickstart on Sun Jul 20 23:00:03 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+FollowUp.ai documentation
+=========================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+

--- a/docs/source/make.bat
+++ b/docs/source/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tests/messaging_core/test_placeholder.py
+++ b/tests/messaging_core/test_placeholder.py
@@ -1,3 +1,6 @@
+"""Tests for the messaging_core package."""
+
+
 def test_placeholder() -> None:
     """Placeholder test for messaging_core."""
     assert True


### PR DESCRIPTION
## Summary
- initialize Sphinx in `docs/source`
- add CI workflow to build docs and run tests
- update backend test command to treat warnings as errors
- add basic module docstrings
- document local doc build steps in README
- ignore built documentation

## Testing
- `pnpm install`
- `pnpm -r test`
- `flake8`
- `pydocstyle docs/source/conf.py tests/messaging_core/test_placeholder.py backend/messaging_core/__init__.py`
- `mypy backend/messaging_core/__init__.py`
- `sphinx-build -b html -n -W docs/source docs/build`

------
https://chatgpt.com/codex/tasks/task_e_687d74a704b0832986be2331b0af519a