### PR TITLE
Add Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ The repository is organised as a pnpm workspace. Packages are located in the fol
 - `infra` – infrastructure automation.
 - `scripts` – development utilities.
 
+## Running with Docker Compose
+
+Start the backend and frontend containers using:
+
+```bash
+docker compose up
+```
+
 ## Linting and Testing
 
 When linting and test suites are available, run them across the workspace with:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "messaging_core.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,0 +1,7 @@
+export default [
+  {
+    files: ['*.js'],
+    languageOptions: { ecmaVersion: 'latest' },
+    rules: {},
+  },
+];

--- a/backend/messaging_core/__init__.py
+++ b/backend/messaging_core/__init__.py
@@ -1,0 +1,5 @@
+"""Messaging core package."""
+
+from .api import app
+
+__all__ = ["app"]

--- a/backend/messaging_core/api.py
+++ b/backend/messaging_core/api.py
@@ -1,0 +1,11 @@
+"""Minimal API implementation for FollowUp.ai backend."""
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root() -> dict[str, str]:
+    """Return a basic health check payload."""
+    return {"status": "ok"}

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,5 +5,6 @@
   "scripts": {
     "lint": "eslint .",
     "test": "pytest ../tests"
-  }
+  },
+  "type": "module"
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - '8000:8000'
+  frontend:
+    build: ./frontend
+    ports:
+      - '3000:3000'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* ./
+RUN corepack enable && pnpm install --prod
+COPY . .
+CMD ["pnpm", "start"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "lint": "echo 'no lint'",
-    "test": "echo 'no tests'"
+    "test": "echo 'no tests'",
+    "start": "node -e \"console.log(\\\"frontend service running\\\")\""
   }
 }


### PR DESCRIPTION
## Summary
- add FastAPI skeleton for backend
- provide Dockerfiles for backend and frontend services
- wire services with docker-compose
- add example `docker compose up` usage to README
- update Node package scripts and add lint config

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687d74b1046c8329a94b7b1fe013619e