### PR TITLE
feat(messaging_core): add message entity schema (task 1)

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for FollowUp.ai."""

--- a/backend/messaging_core/__init__.py
+++ b/backend/messaging_core/__init__.py
@@ -1,1 +1,5 @@
 """Messaging core package."""
+
+from .models import Message
+
+__all__ = ["Message"]

--- a/backend/messaging_core/models.py
+++ b/backend/messaging_core/models.py
@@ -1,0 +1,19 @@
+"""Data models for the messaging core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(slots=True)
+class Message:
+    """Represent a single WhatsApp message."""
+
+    id: UUID
+    conversation_id: UUID
+    sender_id: UUID
+    content: str
+    created_at: datetime
+    status: str

--- a/tests/messaging_core/test_1.py
+++ b/tests/messaging_core/test_1.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import uuid
+from datetime import datetime
+
+from backend.messaging_core.models import Message
+
+
+def test_message_entity_dataclass() -> None:
+    msg = Message(
+        id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+        sender_id=uuid.uuid4(),
+        content="Hello",
+        created_at=datetime(2024, 1, 1, 12, 0, 0),
+        status="sent",
+    )
+    assert msg.content == "Hello"
+    assert msg.status == "sent"


### PR DESCRIPTION
## Summary
- add backend package
- create Message dataclass
- expose Message in messaging_core
- add unit test for message entity

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687d7e29046883299af89e88f124c525