### PR TITLE
Fix backend lint failure handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "lint": "black --check . && docformatter --check -r . && pydocstyle . && flake8 . && mypy . && eslint . && prettier -c '**/*.{js,jsx,ts,tsx}' && stylelint '**/*.css' || true && flow check",
+    "lint": "black --check . && docformatter --check -r . && pydocstyle . && flake8 . && mypy . && eslint . && prettier -c '**/*.{js,jsx,ts,tsx}' && stylelint '**/*.css' && flow check",
     "test": "pytest -W error ../tests"
   },
   "type": "module"


### PR DESCRIPTION
## Summary
- remove `|| true` from `backend/package.json` so stylelint errors fail linting

## Testing
- `pnpm lint` *(fails when stylelint cannot find CSS files)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687d9c3db65c83299778ae639b363757