### PR TITLE
Fix pytest path handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "lint": "black --check . && docformatter --check -r . && pydocstyle . && flake8 . && mypy . && eslint . && prettier -c '**/*.{js,jsx,ts,tsx}' && stylelint '**/*.css' || true && flow check",
-    "test": "pytest -W error ../tests"
+    "test": "PYTHONPATH=.. pytest -W error ../tests"
   },
   "type": "module"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ line-length = 88
 python_version = "3.12"
 strict = true
 
+[tool.pytest.ini_options]
+addopts = "-W error"
+testpaths = ["tests"]
+

--- a/tests/messaging_core/test_1.py
+++ b/tests/messaging_core/test_1.py
@@ -1,6 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import uuid
 from datetime import datetime


### PR DESCRIPTION
## Summary
- configure pytest via PYTHONPATH and ini settings
- remove `sys.path` tweaks from tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687d9c3f12e88329842e06549f564546