### PR TITLE
Fix lint script error handling

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' || true && stylelint '**/*.css' || true && flow check",
+    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' && stylelint '**/*.css' && flow check",
     "test": "echo 'no tests'"
   }
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' || true && stylelint '**/*.css' || true && flow check",
+    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' && stylelint '**/*.css' && flow check",
     "test": "echo 'no tests'"
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' || true && stylelint '**/*.css' || true && flow check",
+    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' && stylelint '**/*.css' && flow check",
     "test": "echo 'no tests'"
   }
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' || true && stylelint '**/*.css' || true && flow check",
+    "lint": "eslint . --no-error-on-unmatched-pattern && prettier -c '**/*.{js,jsx,ts,tsx,css,md}' && stylelint '**/*.css' && flow check",
     "test": "echo 'no tests'"
   }
 }


### PR DESCRIPTION
## Summary
- remove `|| true` from lint commands to fail on Prettier/Stylelint errors

## Testing
- `pnpm lint` *(fails: No files matching the pattern were found)*

------
https://chatgpt.com/codex/tasks/task_e_687e335554e883299e25846d80309b8d