### PR TITLE
Remove sys.path modification in tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "lint": "black --check . && docformatter --check -r . && pydocstyle . && flake8 . && mypy . && eslint . && prettier -c '**/*.{js,jsx,ts,tsx}' && stylelint '**/*.css' && flow check",
-    "test": "pytest -W error ../tests"
+    "test": "PYTHONPATH=.. pytest -W error ../tests"
   },
   "type": "module"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/messaging_core/test_1.py
+++ b/tests/messaging_core/test_1.py
@@ -1,13 +1,8 @@
 """Tests for the Message dataclass."""
 
-import sys
-from pathlib import Path
 import uuid
 from datetime import datetime
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-from backend.messaging_core.models import Message  # noqa: E402
+from backend.messaging_core.models import Message
 
 
 def test_message_entity_dataclass() -> None:


### PR DESCRIPTION
## Summary
- simplify Message model test imports
- configure backend tests via PYTHONPATH
- add pytest.ini for repository-wide configuration

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3352f86483298022eb5e4ff41e0e